### PR TITLE
[tracker-miners] Fix nfo:fileName and nfo:fileLastModified updates. JB#55293 OMP#JOLLA-390

### DIFF
--- a/rpm/0001-Tracker-config-overrides.patch
+++ b/rpm/0001-Tracker-config-overrides.patch
@@ -1,7 +1,7 @@
-From c4cec5e42129ad386425ee64d5dc963a6a761dcf Mon Sep 17 00:00:00 2001
+From bd8b2262d9e96042f928d1950cf0717928b64107 Mon Sep 17 00:00:00 2001
 From: Islam Amer <islam.amer@jollamobile.com>
 Date: Wed, 12 Nov 2014 18:10:53 +0200
-Subject: [PATCH 1/5] Tracker config overrides
+Subject: [PATCH 1/8] Tracker config overrides
 
 [schema] change default miner initial sleep to 30 seconds to not hammer the system during bootup
 Set the default delay for GraphUpdated to 350 instead of upstream default of 1000. Helps fixing JB#11570

--- a/rpm/0002-Fix-systemd-unit-files.patch
+++ b/rpm/0002-Fix-systemd-unit-files.patch
@@ -1,7 +1,7 @@
-From 0f993571f3bc4ad0030eecd4142524978984408c Mon Sep 17 00:00:00 2001
+From a2194287ff7be2711f8129d5874edc1afd9404a4 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Tue, 14 Aug 2018 09:35:50 -0400
-Subject: [PATCH 2/5] Fix systemd unit files
+Subject: [PATCH 2/8] Fix systemd unit files
 
 Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
 ---

--- a/rpm/0003-Prevent-tracker-extract-failing-when-seccomp-loading.patch
+++ b/rpm/0003-Prevent-tracker-extract-failing-when-seccomp-loading.patch
@@ -1,7 +1,7 @@
-From 5de158bcbc1fb926a18c2ed50cb12f9739713ee1 Mon Sep 17 00:00:00 2001
+From a27e73331e42e7e5cb100422aaf04c43f5471ed2 Mon Sep 17 00:00:00 2001
 From: Andrew Branson <andrew.branson@jolla.com>
 Date: Fri, 28 Aug 2020 00:04:51 +0200
-Subject: [PATCH 3/5] Prevent tracker-extract failing when seccomp loading
+Subject: [PATCH 3/8] Prevent tracker-extract failing when seccomp loading
  fails on older kernels. JB#50862
 
 ---

--- a/rpm/0004-Add-also-fileSize-to-the-basic-set-of-file-info-on-a.patch
+++ b/rpm/0004-Add-also-fileSize-to-the-basic-set-of-file-info-on-a.patch
@@ -1,7 +1,7 @@
-From dc638a9a6ce6e0ef2bff3a8bb73a38da2fd4a2eb Mon Sep 17 00:00:00 2001
+From f28e21e5e27304c75ce0d464b31de632cc139e3a Mon Sep 17 00:00:00 2001
 From: Pekka Vuorela <pekka.vuorela@jolla.com>
 Date: Wed, 19 May 2021 13:26:07 +0300
-Subject: [PATCH 4/5] Add also fileSize to the basic set of file info on all
+Subject: [PATCH 4/8] Add also fileSize to the basic set of file info on all
  the graph
 
 No need to depend on FileSystem graph to have the sizes.

--- a/rpm/0005-Fix-database-corruption-caused-by-the-miner-being-re.patch
+++ b/rpm/0005-Fix-database-corruption-caused-by-the-miner-being-re.patch
@@ -1,7 +1,7 @@
-From 4fb7790b946c2903836c42d2cfb8fee0bf4991ce Mon Sep 17 00:00:00 2001
+From 2d180086e2859b9a282e1c9338fa73424a498107 Mon Sep 17 00:00:00 2001
 From: Pekka Vuorela <pekka.vuorela@jolla.com>
 Date: Wed, 7 Jul 2021 13:05:57 +0300
-Subject: [PATCH 5/5] Fix database corruption caused by the miner being
+Subject: [PATCH 5/8] Fix database corruption caused by the miner being
  restarted during setup.
 
 Install the signal handlers before starting database setup so if the

--- a/rpm/0006-Allow-D-Bus-activation-only-through-systemd.patch
+++ b/rpm/0006-Allow-D-Bus-activation-only-through-systemd.patch
@@ -1,7 +1,7 @@
-From b0e5d5695782599bf7d32919a60826bf77c01953 Mon Sep 17 00:00:00 2001
+From d92cd99e6558e867bcb914cdb1559aaf67f9fd34 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Thu, 12 Aug 2021 08:26:21 +0300
-Subject: [PATCH] Allow D-Bus activation only through systemd
+Subject: [PATCH 6/8] Allow D-Bus activation only through systemd
 
 Starting D-Bus services should happen only via systemd. Using a dummy
 Exec line in D-Bus configuration ensures that systemd can't be bypassed.
@@ -72,5 +72,5 @@ index 484fa2f81..8bc3425c4 100644
 +Exec=/bin/false
  SystemdService=tracker-writeback-3.service
 -- 
-2.17.1
+2.31.1
 

--- a/rpm/0007-Update-nfo-fileName-on-content-specific-graphs-too-w.patch
+++ b/rpm/0007-Update-nfo-fileName-on-content-specific-graphs-too-w.patch
@@ -1,0 +1,38 @@
+From 5765e58d901e6ac9e9b68f47390ef70e16f7dccc Mon Sep 17 00:00:00 2001
+From: Pekka Vuorela <pekka.vuorela@jolla.com>
+Date: Tue, 21 Sep 2021 18:26:24 +0300
+Subject: [PATCH 7/8] Update nfo:fileName on content specific graphs too when
+ moved
+
+Moved files were updating nfo:fileName only in tracker:FileSystem.
+
+Fixes: https://gitlab.gnome.org/GNOME/tracker-miners/-/issues/194
+---
+ src/miners/fs/tracker-miner-files.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/miners/fs/tracker-miner-files.c b/src/miners/fs/tracker-miner-files.c
+index fb7b3152f..d1c1dc841 100644
+--- a/src/miners/fs/tracker-miner-files.c
++++ b/src/miners/fs/tracker-miner-files.c
+@@ -2423,14 +2423,16 @@ miner_files_move_file (TrackerMinerFS      *fs,
+ 	                        "} INSERT {"
+ 	                        "  GRAPH ?g {"
+ 	                        "    <%s> a nfo:FileDataObject ; "
++	                        "         nfo:fileName \"%s\" ; "
+ 	                        "         ?p ?o "
+ 	                        "  }"
+ 	                        "} WHERE {"
+ 	                        "  GRAPH ?g {"
+ 	                        "    <%s> ?p ?o "
+ 	                        "  }"
++	                        "  FILTER (?p != nfo:fileName) . "
+ 	                        "}",
+-	                        source_uri, uri, source_uri);
++	                        source_uri, uri, display_name, source_uri);
+ 	g_free (container_clause);
+ 
+ 	if (recursive) {
+-- 
+2.31.1
+

--- a/rpm/0008-Update-nfo-fileLastModified-also-on-content-specific.patch
+++ b/rpm/0008-Update-nfo-fileLastModified-also-on-content-specific.patch
@@ -1,0 +1,49 @@
+From 3ca4979071a832aabddfb99b7f3933d6993f35c3 Mon Sep 17 00:00:00 2001
+From: Pekka Vuorela <pekka.vuorela@jolla.com>
+Date: Tue, 21 Sep 2021 19:38:08 +0300
+Subject: [PATCH 8/8] Update nfo:fileLastModified also on content specific
+ graphs
+
+Executing 'touch' on a file was updating only tracker:FileSystem.
+---
+ src/miners/fs/tracker-miner-files.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/miners/fs/tracker-miner-files.c b/src/miners/fs/tracker-miner-files.c
+index d1c1dc841..d886650e6 100644
+--- a/src/miners/fs/tracker-miner-files.c
++++ b/src/miners/fs/tracker-miner-files.c
+@@ -2190,9 +2190,10 @@ miner_files_process_file_attributes (TrackerMinerFS      *fs,
+                                      GFileInfo           *info,
+                                      TrackerSparqlBuffer *buffer)
+ {
+-	TrackerResource *resource;
++	TrackerResource *resource, *graph_file;
+ 	time_t time_;
+ 	gchar *uri, *time_str;
++	const gchar *mime_type, *graph;
+ 	GDateTime *modified;
+ 
+ 	uri = g_file_get_uri (file);
+@@ -2210,9 +2211,18 @@ miner_files_process_file_attributes (TrackerMinerFS      *fs,
+ 	if (!modified)
+ 		modified = g_date_time_new_from_unix_utc (0);
+ 
++	mime_type = g_file_info_get_content_type (info);
++	graph = tracker_extract_module_manager_get_graph (mime_type);
++
+ 	/* Update nfo:fileLastModified */
+ 	time_str = g_date_time_format_iso8601 (modified);
+ 	tracker_resource_set_string (resource, "nfo:fileLastModified", time_str);
++	if (graph) {
++		graph_file = tracker_resource_new (uri);
++		tracker_resource_set_string (graph_file, "nfo:fileLastModified", time_str);
++		tracker_sparql_buffer_push (buffer, file, graph, graph_file);
++		g_clear_object (&graph_file);
++	}
+ 	g_date_time_unref (modified);
+ 	g_free (time_str);
+ 
+-- 
+2.31.1
+

--- a/rpm/tracker-miners.spec
+++ b/rpm/tracker-miners.spec
@@ -13,6 +13,8 @@ Patch3:     0003-Prevent-tracker-extract-failing-when-seccomp-loading.patch
 Patch4:     0004-Add-also-fileSize-to-the-basic-set-of-file-info-on-a.patch
 Patch5:     0005-Fix-database-corruption-caused-by-the-miner-being-re.patch
 Patch6:     0006-Allow-D-Bus-activation-only-through-systemd.patch
+Patch7:     0007-Update-nfo-fileName-on-content-specific-graphs-too-w.patch
+Patch8:     0008-Update-nfo-fileLastModified-also-on-content-specific.patch
 
 BuildRequires:  meson >= 0.50
 BuildRequires:  gettext


### PR DESCRIPTION
Changes on these weren't updated to content specific graphs on all the cases.
The first patch already merged to upstream, second having an open PR
at the moment.

@spiiroin @adenexter @okodron 