### PR TITLE
[tracker-miners] Add backported patch to fix crash. JB#58622

### DIFF
--- a/rpm/0007-backport-tracker-extract-libav-Check-for-all-tags-al.patch
+++ b/rpm/0007-backport-tracker-extract-libav-Check-for-all-tags-al.patch
@@ -1,7 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
 Date: Sat, 27 Aug 2022 17:17:46 +0300
-Subject: [PATCH] tracker-extract-libav: Check for all tags also from streams
+Subject: [PATCH] backport: tracker-extract-libav: Check for all tags also from
+ streams
 
 At least in Ogg audio and video files the tags are actually inside the
 streams not in the format context. Check for the tags in suitable streams

--- a/rpm/0008-backport-tracker-extract-libav-Add-missing-include.patch
+++ b/rpm/0008-backport-tracker-extract-libav-Add-missing-include.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
+Date: Sat, 27 Aug 2022 17:15:03 +0300
+Subject: [PATCH] backport: tracker-extract-libav: Add missing include
+
+Nothing was used from tracker-utils.h so replace it with missing
+tracker-file-utils.h. Missing header was causing a build warning
+and crashing the tracker-extract process.
+---
+ src/tracker-extract/tracker-extract-libav.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tracker-extract/tracker-extract-libav.c b/src/tracker-extract/tracker-extract-libav.c
+index 7c1cd3fb7a1953f8912d86deb3e021b520cbd11c..c5cfaae6df22281ec9d2df980bbda14a48be0074 100644
+--- a/src/tracker-extract/tracker-extract-libav.c
++++ b/src/tracker-extract/tracker-extract-libav.c
+@@ -22,7 +22,7 @@
+ #include <glib.h>
+ 
+ #include <libtracker-sparql/tracker-ontologies.h>
+-#include <libtracker-miners-common/tracker-utils.h>
++#include <libtracker-miners-common/tracker-file-utils.h>
+ 
+ #include <libtracker-extract/tracker-extract.h>
+ 

--- a/rpm/tracker-miners.spec
+++ b/rpm/tracker-miners.spec
@@ -14,7 +14,8 @@ Patch3:     0003-Prevent-tracker-extract-failing-when-seccomp-loading.patch
 Patch4:     0004-Fix-database-corruption-caused-by-the-miner-being-re.patch
 Patch5:     0005-Allow-D-Bus-activation-only-through-systemd.patch
 Patch6:     0006-backport-Avoid-non-existing-nfo-language-on-libav-ex.patch
-Patch7:     0007-tracker-extract-libav-Check-for-all-tags-also-from-s.patch
+Patch7:     0007-backport-tracker-extract-libav-Check-for-all-tags-al.patch
+Patch8:     0008-backport-tracker-extract-libav-Add-missing-include.patch
 
 BuildRequires:  meson >= 0.50
 BuildRequires:  gettext


### PR DESCRIPTION
Adds missing include causing crash in some situations.
Rename patch number 7 to indicate it's a backported patch.