### PR TITLE
[tracker-miners] Update to 3.3.3. JB#61614

### DIFF
--- a/rpm/0003-Prevent-tracker-extract-failing-when-seccomp-loading.patch
+++ b/rpm/0003-Prevent-tracker-extract-failing-when-seccomp-loading.patch
@@ -9,10 +9,10 @@ Subject: [PATCH] Prevent tracker-extract failing when seccomp loading fails on
  1 file changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/src/libtracker-miners-common/tracker-seccomp.c b/src/libtracker-miners-common/tracker-seccomp.c
-index 88fbbe197e36c4a21d59adf9e6eaffda5e6f7c64..b4016b69b1522d27a7ea2b7ecf87400fe9c50099 100644
+index 374800ddd55f7e84046270169dcae33815b25d5d..334daab0787510a6179cb47f3914dc2833244f66 100644
 --- a/src/libtracker-miners-common/tracker-seccomp.c
 +++ b/src/libtracker-miners-common/tracker-seccomp.c
-@@ -274,11 +274,16 @@ tracker_seccomp_init (void)
+@@ -302,11 +302,16 @@ tracker_seccomp_init (void)
  #endif
  
  	g_debug ("Loading seccomp rules.");

--- a/rpm/0004-Fix-database-corruption-caused-by-the-miner-being-re.patch
+++ b/rpm/0004-Fix-database-corruption-caused-by-the-miner-being-re.patch
@@ -12,10 +12,10 @@ event loop is started and the queued signal handler is processed.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/miners/fs/tracker-main.c b/src/miners/fs/tracker-main.c
-index 52cb4ed7c14eb4db5bff3b70db8a577f39e7022f..493d2220a91fddad1ae4f8802c0ab22b42852c9a 100644
+index 27da5e1a1d2f248b4e3b3ac1b42f648b43529e80..21f6166bc2e931714ed798747d3bd32cba23d88d 100644
 --- a/src/miners/fs/tracker-main.c
 +++ b/src/miners/fs/tracker-main.c
-@@ -1033,6 +1033,8 @@ main (gint argc, gchar *argv[])
+@@ -1044,6 +1044,8 @@ main (gint argc, gchar *argv[])
  
  	main_loop = g_main_loop_new (NULL, FALSE);
  
@@ -24,7 +24,7 @@ index 52cb4ed7c14eb4db5bff3b70db8a577f39e7022f..493d2220a91fddad1ae4f8802c0ab22b
  	if (no_daemon) {
  		g_debug ("tracker-miner-fs-3 running in --no-daemon mode.");
  	} else if (domain_ontology_name) {
-@@ -1176,8 +1178,6 @@ main (gint argc, gchar *argv[])
+@@ -1187,8 +1189,6 @@ main (gint argc, gchar *argv[])
  	if (do_crawling)
  		miner_start (miner_files, config, do_mtime_checking);
  

--- a/rpm/0009-backport-tracker-miner-fs-Allow-building-without-gst.patch
+++ b/rpm/0009-backport-tracker-miner-fs-Allow-building-without-gst.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
+Date: Fri, 23 Feb 2024 21:31:55 +0200
+Subject: [PATCH] backport: tracker-miner-fs: Allow building without gstreamer
+
+Build fails when using generic_media_extractor=libav and
+not having gstreamer headers installed.
+---
+ src/miners/fs/tracker-main.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/miners/fs/tracker-main.c b/src/miners/fs/tracker-main.c
+index 21f6166bc2e931714ed798747d3bd32cba23d88d..eb0b23883dfc8c0ab76424e3d9fc02e20a4c7d4e 100644
+--- a/src/miners/fs/tracker-main.c
++++ b/src/miners/fs/tracker-main.c
+@@ -35,7 +35,9 @@
+ #include <glib-object.h>
+ #include <glib/gi18n.h>
+ 
++#if defined(HAVE_GSTREAMER)
+ #include <gst/gst.h>
++#endif
+ 
+ #include <libtracker-miners-common/tracker-common.h>
+ #include <libtracker-sparql/tracker-sparql.h>
+@@ -989,7 +991,9 @@ main (gint argc, gchar *argv[])
+ 	/* Preempt possible registry updates, before tracker-extract-3 deals
+ 	 * with gstreamer plugins.
+ 	 */
++#if defined(HAVE_GSTREAMER)
+ 	gst_init (NULL, NULL);
++#endif
+ 
+ 	/* Translators: this messagge will apper immediately after the
+ 	 * usage string - Usage: COMMAND <THIS_MESSAGE>

--- a/rpm/0010-backport-seccomp-Allow-epoll_create1.patch
+++ b/rpm/0010-backport-seccomp-Allow-epoll_create1.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sam Thursfield <sam.thursfield@codethink.co.uk>
+Date: Mon, 17 Oct 2022 11:32:00 +0200
+Subject: [PATCH] backport: seccomp: Allow epoll_create1()
+
+This is preferred over epoll_create(), and is used in GLib 2.74 and
+later due to https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2868
+
+https://gitlab.gnome.org/GNOME/tracker-miners/-/issues/239
+---
+ src/libtracker-miners-common/tracker-seccomp.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/libtracker-miners-common/tracker-seccomp.c b/src/libtracker-miners-common/tracker-seccomp.c
+index 334daab0787510a6179cb47f3914dc2833244f66..ec271495fe986b6b4999be2a10321c45c1588133 100644
+--- a/src/libtracker-miners-common/tracker-seccomp.c
++++ b/src/libtracker-miners-common/tracker-seccomp.c
+@@ -208,6 +208,7 @@ tracker_seccomp_init (void)
+ 	ALLOW_RULE (pipe);
+ 	ALLOW_RULE (pipe2);
+ 	ALLOW_RULE (epoll_create);
++	ALLOW_RULE (epoll_create1);
+ 	ALLOW_RULE (epoll_ctl);
+ 	/* System */
+ 	ALLOW_RULE (uname);

--- a/rpm/tracker-miners.spec
+++ b/rpm/tracker-miners.spec
@@ -1,6 +1,6 @@
 Name:       tracker-miners
 Summary:    Tracker miners and metadata extractors
-Version:    3.3.1
+Version:    3.3.3
 Release:    1
 License:    LGPLv2+ and GPLv2+
 URL:        https://gnome.pages.gitlab.gnome.org/tracker/
@@ -16,6 +16,8 @@ Patch5:     0005-Allow-D-Bus-activation-only-through-systemd.patch
 Patch6:     0006-backport-Avoid-non-existing-nfo-language-on-libav-ex.patch
 Patch7:     0007-backport-tracker-extract-libav-Check-for-all-tags-al.patch
 Patch8:     0008-backport-tracker-extract-libav-Add-missing-include.patch
+Patch9:     0009-backport-tracker-miner-fs-Allow-building-without-gst.patch
+Patch10:    0010-backport-seccomp-Allow-epoll_create1.patch
 
 BuildRequires:  meson >= 0.50
 BuildRequires:  gettext


### PR DESCRIPTION
Backport patch to allow building without gstreamer. Backport patch to allow epoll_create1 in seccomp.