### PR TITLE
[localsearch] Reset database when updating to localsearch. JB#63570

### DIFF
--- a/rpm/tracker-reset.sh
+++ b/rpm/tracker-reset.sh
@@ -1,0 +1,5 @@
+#/bin/sh
+if [ ! -e ~/.local/share/localsearch-migrated ]; then
+    tracker3 reset -s
+    touch ~/.local/share/localsearch-migrated
+fi


### PR DESCRIPTION
There seems to have been some problems on getting indexed content shown when updating devices from older versions, and database reset helping there.

Let's try this to ensure we don't have problems related to database created with an older version. To be seen if something else is needed.

Script and setup resurrected from commit ba5b6e029fde26 with changed migration file path.