### PR TITLE
update upstream to version 3.10.2

### DIFF
--- a/rpm/localsearch.spec
+++ b/rpm/localsearch.spec
@@ -1,6 +1,6 @@
 Name:       localsearch
 Summary:    Tracker miners and metadata extractors
-Version:    3.9.0
+Version:    3.10.2
 Release:    1
 License:    LGPLv2+ and GPLv2+
 URL:        https://gnome.pages.gitlab.gnome.org/localsearch/


### PR DESCRIPTION
beside other fixes and iprovements it is fixing
extraction of gps coordinates from photos,
see https://gitlab.gnome.org/GNOME/localsearch/-/issues/422

not tested on the SFOS yet